### PR TITLE
fix-regex-expression

### DIFF
--- a/app/Http/Controllers/CustomerController.php
+++ b/app/Http/Controllers/CustomerController.php
@@ -47,7 +47,7 @@ class CustomerController extends Controller
             if ($customers) {
                 $validatedCurstomers = $this->validadePhoneNumberService->validatePhoneNumber($customers);
 
-                if ($request['status']) {
+                if (!is_null($request['status'])) {
                     foreach ($validatedCurstomers as $key => $customer) {
                         if ($customer->isValid != intval($request['status'])) {
                             $validatedCurstomers->forget($key);
@@ -57,9 +57,9 @@ class CustomerController extends Controller
 
                 $status = $request['status'] ? 'status :' . $request['status'] . ' and ' : null;
                 $country = $request['country'] ? 'country code: ' . $request['country'] : null;
-
                 session()->flash('success', 'Filtered by: ' . $status . $country);
-                return view('welcome', compact('validatedCurstomers'));
+                $isFilter = true;
+                return view('welcome', compact('validatedCurstomers', $isFilter));
             }
         } catch (Exception $e) {
             return redirect()->back()->with('danger', $e->getMessage(), 400);

--- a/app/Repositories/CustomerRepository.php
+++ b/app/Repositories/CustomerRepository.php
@@ -18,6 +18,6 @@ class CustomerRepository
             if ($request['country']) {
                 $query->where('phone', 'like', '%' . $request['country'] . '%');
             }
-        })->paginate(10);
+        })->paginate(100);
     }
 }

--- a/app/Services/ValidadePhoneNumberService.php
+++ b/app/Services/ValidadePhoneNumberService.php
@@ -13,11 +13,11 @@ class ValidadePhoneNumberService
     private $ugandaCode = '256';
 
     //Regex expressions
-    private $camerronRegex = '/(\+237|237)\s(6|2)(2|3|[5-9])[0-9]{7}/';
-    private $ethiopiaRegex = '/(251)\ ?[1-59]\d{8}$/';
-    private $moroccoRegex = '/(212)\ ?[5-9]\d{8}$/';
-    private $MozambiqueRegex = '/(258)\ ?[28]\d{7,8}$/';
-    private $Ugandagex = '/\(256\)\s\d{4,5}-?\d{4}/';
+    private $camerronRegex = '/\(237\)\ ?[2368]\d{7,8}$/';
+    private $ethiopiaRegex = '/\(251\)\ ?[1-59]\d{8}$/';
+    private $moroccoRegex = '/\(212\)\ ?[5-9]\d{8}$/';
+    private $MozambiqueRegex = '/\(258\)\ ?[28]\d{7,8}$/';
+    private $Ugandagex = '/\(256\)\ ?\d{9}$/';
 
 
     public function validatePhoneNumber($customers): mixed

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -98,7 +98,7 @@
             </table>
             <br />
             <br />
-            {{ $validatedCurstomers->withQueryString()->links() }}
+            {{$validatedCurstomers->withQueryString()->links() }}
         </div>
     </div>
 


### PR DESCRIPTION
Regex fix.
Need to include validation bars. Previous expressions were wrong. New regex added

private $camerronRegex = '/\(237\)\ ?[2368]\d{7,8}$/';
private $ethiopiaRegex = '/\(251\)\ ?[1-59]\d{8}$/';
private $moroccoRegex = '/\(212\)\ ?[5-9]\d{8}$/';
private $MozambiqueRegex = '/\(258\)\ ?[28]\d{7,8}$/';
private $Ugandagex = '/\(256\)\ ?\d{9}$/';